### PR TITLE
Use AUTH_USER_MODEL

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -30,8 +30,13 @@ Installation
 * To grant a user access the waitinglist management views, first
   ensure you've synced the database to create the
   ``waitinglist.manage_cohorts`` permission::
+   
+   from django.conf import settings
+   from django.contrib.auth.models import Permission
+   
 
-   from django.contrib.auth.models import User, Permission
+   User = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
+
 
    user = User.objects.get(username="finnegan")
    permission = Permission.objects.get(codename="manage_cohorts")

--- a/waitinglist/models.py
+++ b/waitinglist/models.py
@@ -11,11 +11,11 @@ from django.template.defaultfilters import slugify
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
-from django.contrib.auth.models import User
-
 from account.models import SignupCode, SignupCodeResult
 from account.signals import user_signed_up
 
+
+User = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
 SURVEY_SECRET = getattr(settings, "WAITINGLIST_SURVEY_SECRET", settings.SECRET_KEY)
 

--- a/waitinglist/stats.py
+++ b/waitinglist/stats.py
@@ -1,12 +1,15 @@
 import datetime
 
-from django.utils import timezone
+from django.conf import settings
 
-from django.contrib.auth.models import User
+from django.utils import timezone
 
 from account.models import SignupCode
 
 from waitinglist.models import WaitingListEntry
+
+
+User = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
 
 def stats():

--- a/waitinglist/views.py
+++ b/waitinglist/views.py
@@ -1,5 +1,6 @@
 import json
 
+from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponse
 from django.shortcuts import render, redirect, get_object_or_404
@@ -7,7 +8,6 @@ from django.template import RequestContext
 from django.template.loader import render_to_string
 from django.views.decorators.http import require_POST
 
-from django.contrib.auth.models import User
 from django.contrib.auth.decorators import permission_required
 
 from account.models import SignupCode
@@ -16,6 +16,9 @@ from account.decorators import login_required
 from .forms import WaitingListEntryForm, CohortCreate, SurveyForm
 from .models import WaitingListEntry, Cohort, SignupCodeCohort, SurveyInstance
 from .signals import signed_up
+
+
+User = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
 
 @require_POST


### PR DESCRIPTION
- Waitinglist should work with custom user models
- Changed instances of "django.contrib.auth.models import User" to "User = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')"